### PR TITLE
GTD-58 search GA event tracking

### DIFF
--- a/lib/assets/javascripts/_modules/search.js
+++ b/lib/assets/javascripts/_modules/search.js
@@ -67,6 +67,20 @@
         $searchInput.focus();
         hideResults();
       });
+
+      // Attach analytics events to search result clicks
+      if(window.ga) {
+        $searchResults.on('click', '.search-result__title a', function() {
+          var href = $(this).attr('href');
+          ga('send', {
+            hitType: 'event',
+            eventCategory: 'Search result',
+            eventAction: 'click',
+            eventLabel: href,
+            transport: 'beacon'
+          });
+        });
+      }
     }
 
     function getResults(query) {

--- a/lib/assets/javascripts/_modules/search.js
+++ b/lib/assets/javascripts/_modules/search.js
@@ -15,6 +15,8 @@
     var $searchResultsWrapper;
     var $searchResultsClose;
     var results;
+    var query;
+    var queryTimer;
     var maxSearchEntries = 10;
 
     this.start = function start($element) {
@@ -46,12 +48,16 @@
       // Search functionality on search text input
       $searchInput.on('input', function (e) {
         e.preventDefault();
-        var query = $(this).val();
+        query = $(this).val();
         s.search(query, function(r) {
           results = r;
           renderResults(query);
           updateTitle();
         });
+        if(window.ga) {
+          window.clearTimeout(queryTimer);
+          queryTimer = window.setTimeout(sendQueryToAnalytics, 1000);
+        }
       });
 
       // Set focus on the first search result instead of submiting the search
@@ -180,6 +186,16 @@
       $searchResultsWrapper.removeClass('is-open')
       .attr('aria-hidden', 'true');
       $html.removeClass('has-search-results-open');
+    }
+
+    function sendQueryToAnalytics() {
+      ga('send', {
+        hitType: 'event',
+        eventCategory: 'Search query',
+        eventAction: 'type',
+        eventLabel: query,
+        transport: 'beacon'
+      });
     }
   };
 


### PR DESCRIPTION
This adds Google Analytics tracking events to search result clicks and search queries. It waits for one second of non-typing before sending the event, to avoid sending partial search terms.

I took a guess at the event category, if there are more common categories to use let me know.